### PR TITLE
Tls copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dist
 *.hp
 *.ps
 .vagrant
+~*
+*~

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "dependencies/http-client-tls-0.3.3-shim"]
+	path = dependencies/http-client-tls-0.3.3-shim
+	url = git@github.com:jfischoff/http-client.git

--- a/README.md
+++ b/README.md
@@ -13,25 +13,25 @@ cabal run example -- --concurrency=1000 --run-timed=1000000000 --interactive +RT
 
 ### Example Script
 
-```
-testScript :: Int -> Recorder -> IO ()
-testScript port recorder = do
+```haskell
+testScript :: Int -> ConnectionContext -> Recorder -> IO ()
+testScript port cxt rec = withSession cxt rec $ \sess -> do
   Root { products
        , login
        , checkout
-       }             <- get recorder "root"     (rootRef port)
-  firstProduct : _   <- get recorder "products" products
-  userRef            <- rpc recorder "login"    login
-                                                ( Credentials
-                                                  { userName = "a@example.com"
-                                                  , password = "password"
-                                                  }
-                                                )
-  User { usersCart } <- get recorder "user"     userRef
-  Cart { items }     <- get recorder "cart"     usersCart
+       }             <- get sess (rootRef port)
+  firstProduct : _   <- get sess products
+  userRef            <- rpc sess login
+                                  ( Credentials
+                                    { userName = "a@example.com"
+                                    , password = "password"
+                                    }
+                                  )
+  User { usersCart } <- get sess userRef
+  Cart { items }     <- get sess usersCart
 
-  insert "items" items firstProduct
-  rpc "checkout" checkout cart
+  insert sess items firstProduct
+  rpc sess checkout cart
 ```
 
 For this example `stub` server.

--- a/examples/Client.md
+++ b/examples/Client.md
@@ -1,8 +1,8 @@
-# Building a API client for profiling with `wrecker`
+# Building a Profiling Client with `wrecker`
 
-Unlike most HTTP benchmarking applications, `wrecker` is intended to benchmark
-HTTP calls inline with other forms of processing. This allows for complex
-interactions necessary to benchmark certain API endpoints.
+`wrecker` is intended to benchmark HTTP calls inline with other forms of
+processing. This allows for complex interactions necessary to benchmark
+certain API endpoints.
 
 ## TL;DR
 
@@ -10,24 +10,24 @@ interactions necessary to benchmark certain API endpoints.
 
 Here is the example we will build.
 
-    testScript :: Int -> Recorder -> IO ()
-    testScript port recorder = do
+    testScript :: Int -> ConnectionContext -> Recorder -> IO ()
+    testScript port cxt rec = withSession cxt rec $ \sess -> do
       Root { products
            , login
            , checkout
-           }             <- get recorder "root"     (rootRef port)
-      firstProduct : _   <- get recorder "products" products
-      userRef            <- rpc recorder "login"    login
-                                                    ( Credentials
-                                                      { userName = "a@example.com"
-                                                      , password = "password"
-                                                      }
-                                                    )
-      User { usersCart } <- get recorder "user"     userRef
-      Cart { items }     <- get recorder "cart"     usersCart
+           }             <- get sess (rootRef port)
+      firstProduct : _   <- get sess products
+      userRef            <- rpc sess login
+                                      ( Credentials
+                                        { userName = "a@example.com"
+                                        , password = "password"
+                                        }
+                                      )
+      User { usersCart } <- get sess userRef
+      Cart { items }     <- get sess usersCart
 
-      insert "items" items firstProduct
-      rpc "checkout" checkout cart
+      insert sess items firstProduct
+      rpc sess checkout cart
 
 If this doesn't make sense on inspection, that is okay. This file builds up all
 the necessary utilities and documents every line.
@@ -35,10 +35,17 @@ the necessary utilities and documents every line.
 Most of the code in this file is "generic". It is the type of boilerplate you
 make once for an API client.
 
-You don't need to make a polish API client to use `wrecker`, just look at
-TODO_MAKE_AESON_LENS_EXAMPLE to see how to use `record` with less setup.
+You don't need to make a polished typed API client to use `wrecker`,
+just look at TODO_MAKE_AESON_LENS_EXAMPLE.
 
-## Boring Haskell Prelude
+## Outline
+ - [Boring Haskell Prelude](#Boring_Haskell_Prelude)
+ - [Make a Somewhat Generic JSON API](#Make_a_Somewhat_Generic_JSON_API)
+ - [Make a Somewhat Generic REST API](#Make_a_Somewhat_Generic_REST_API)
+ - [The Example API](#The_Example_API)
+ - [Profiling Script](#Profiling_Script)
+
+## <a name="Boring_Haskell_Prelude"> Boring Haskell Prelude
 
 This is Haskell, so first we turn on the extensions we would like to use.
 
@@ -55,8 +62,11 @@ This is Haskell, so first we turn on the extensions we would like to use.
 - `NamedFieldPuns` will let us destructure records conveniently. 
 - `DeriveAnyClass` and `DeriveGeneric` are used turned on so the compiler
   can generate the JSON conversion functions for us automatically.
-- `OverloadedStrings` is a here so redditors don't yell at me for using `String` instead of `Text`
-- `DuplicateRecordFields` let's us use the `username` field in two records ... welcome to the future.
+- `OverloadedStrings` is a here so redditors don't yell at me for using
+  `String` instead of `Text`
+- `DuplicateRecordFields` let's us use the `username` field in two records ...
+  welcome to the future.
+- `CPP` ... ignore that ...
 
 ```haskell
 #ifndef _CLIENT_IS_MAIN_
@@ -65,28 +75,18 @@ module Client where
 ```
 Not the drones ...
 
-
-### The Essence of `wrecker` is `record`
-
-Introducing `wrecker`
+### The Essence of `wrecker`
 
 ```haskell
-import Wrecker (record, defaultMain, Recorder)
+import Wrecker (defaultMain, Recorder)
 ```
 
-- `record` is the primary function from `wrecker`. It has the signature
-    ```
-     record :: Recorder -> String -> IO a -> IO a
-    ```
-
-  `record` takes a `Recorder` and key in the form of a `String` and wraps some
-  `IO` action. `record` runs the passed in `IO a` and um ... records information
-  about such as the elapsed time and whether it succeeded or failed.
 - `defaultMain` is one of two entry points `wrecker` provides (the other is
   `run`). `defaultMain` performs command line argument parsing for us, and
   runs the benchmarks with the provided options.
-- `Recorder` is an opaque type we can call `record` with. `defaultMain` and `run`
-  create a `Recorder` that is used by all the benchmark scripts.
+- `Recorder` is an opaque type we can call `record` with. This is happens
+  automatically when using the calls in `Network.Wreq.Wrecker`. `defaultMain`
+  and `run` create a `Recorder` that is used by all the benchmark scripts.
 
 ```haskell
 import Data.Aeson
@@ -94,16 +94,16 @@ import Data.Aeson
 We need JSON so of course we are using `aeson`.
 
 ```haskell
+import Network.Wreq (Response)
 import qualified Network.Wreq as Wreq
-import Network.Wreq.Session (Session)
-import qualified Network.Wreq.Session as SWreq
+import Network.Wreq.Wrecker (Session)
+import qualified Network.Wreq.Wrecker as WW
+import Network.Connection (ConnectionContext)
+import qualified Network.Connection as Connection
 ```
-`wrecker` does not provide any means for making HTTP calls. It records data,
-computes statistics, controls concurrency and provides a convenient UI.
-We leverage `wreq` to do the actual HTTP calls.
-
-Here we wrap `wreq`'s `get` and `post` calls and make new functions which take
-a `Recorder` so we can benchmark the times.
+`wrecker` provides a wrapped version of `Network.Wreq.Session` called
+`Network.Wreq.Wrecker`. Importing is the quickest way to write a benchmark with
+`wrecker`
 
 #### Other packages you can mostly ignore
 ```haskell
@@ -111,63 +111,70 @@ import GHC.Generics
 import Data.ByteString.Lazy (ByteString)
 import Data.Text (Text)
 import Data.Text as T
-import Network.HTTP.Client (responseBody, defaultManagerSettings)
+import Network.HTTP.Client (responseBody)
 ```
 
-## Make a Somewhat Generic JSON API
+## <a name="Make_a_Somewhat_Generic_JSON_API"> Make a Somewhat Generic JSON API
 
 `wreq` is pretty easy to use for JSON APIs but it could be easier. Here we make
-a quick wrapper around `wreq` specialized to JSON and we utilize `record`
+a quick wrapper around `wreq` specialized to JSON
 
 ### The Envelope
 
 We wrap all JSON in sent to and from the server in an envelope,
 mainly so we can also serialize a json object as opposed to an array.
 
+The envelope is serialized to JSON with the following format
+```json
+{"value" : RESPONSE_SPECIFIC_OUTPUT }
+```
+It is represented in Haskell as
 ```haskell
-data Envelope a = Envelope { value :: a } -- <=> -- {"value" : toJSON a}
+data Envelope a = Envelope { value :: a }
   deriving (Show, Eq, Generic, FromJSON, ToJSON)
 ```
 
 The `Envelope` only exists to transmit data between the server and the browser.
 - We wrap values going to the server in an `Envelope`
 
-    ```haskell
-    toEnvelope :: ToJSON a => a -> Value
-    toEnvelope = toJSON . Envelope
-    ```
+  ```haskell
+  toEnvelope :: ToJSON a => a -> Value
+  toEnvelope = toJSON . Envelope
+  ```
 
 - We unwrap values coming from the server in `Envelope`.
 
-    ```haskell
-    fromEnvelope :: FromJSON a => IO (Wreq.Response ByteString) -> IO a
-    fromEnvelope x = fmap (value . responseBody) . Wreq.asJSON =<< x
-    ```
+  ```haskell
+  fromEnvelope :: FromJSON a => IO (Response ByteString) -> IO a
+  fromEnvelope x = fmap (value . responseBody) . Wreq.asJSON =<< x
+  ```
 
-- If we wrap inputs and unwrap outputs we can wrap a whole function.
+- If we wrap inputs and unwrap outputs so we can wrap a whole function.
 
-    ```haskell
-    liftEnvelope :: (ToJSON a, FromJSON b)
-                 => (Value -> IO (Wreq.Response ByteString))
-                 -> (a     -> IO b                         )
-    liftEnvelope f = fromEnvelope . f . toEnvelope
-    ```
+  ```haskell
+  liftEnvelope :: (ToJSON a, FromJSON b)
+               => (Value -> IO (Response ByteString))
+               -> (a     -> IO b                    )
+  liftEnvelope f = fromEnvelope . f . toEnvelope
+  ```
 
-### Wrap HTTP Calls with `record`
+### Hide the Envelope
 
-Not only do we want to wrap and unwrap types from our `Envelope`, we also need to wrap api calls with `record`.
+We hide the `Envelope` in JSON specialized `get`s and `post`s.
 
 ```haskell
-jsonGet :: FromJSON a => Session -> Recorder -> String -> Text -> IO a
-jsonGet sess recorder key url = fromEnvelope $ record recorder key $ SWreq.get sess (T.unpack url)
+jsonGet :: FromJSON a => Session -> Text -> IO a
+jsonGet sess url = fromEnvelope $ WW.get sess (T.unpack url)
 
-jsonPost :: (ToJSON a, FromJSON b) => Session -> Recorder -> String -> Text -> a -> IO b
-jsonPost sess recorder key url = liftEnvelope $ record recorder key . SWreq.post sess (T.unpack url)
+jsonPost :: (ToJSON a, FromJSON b) => Session -> Text -> a -> IO b
+jsonPost sess url = liftEnvelope $ WW.post sess (T.unpack url)
 ```
 
-## Make a Somewhat Generic REST API
+## <a name="Make_a_Somewhat_Generic_REST_API"> Make a Somewhat Generic REST API
 
 ### Resource References
+Working with JSON is okay, but this is Haskell we would rather work with
+types.
 
 We represent resource urls using the type `Ref`
 ```haskell
@@ -213,25 +220,28 @@ for our more specific REST and RPC calls.
 - `get` takes a `Ref a` and returns an `a`. The `a` could be something
   like `Cart` or it could be a list like `[Ref a]`.
 
-    ```haskell
-    get :: FromJSON a => (Session, Recorder) -> String -> Ref a -> IO a
-    get (sess, recorder) key (Ref url) = jsonGet sess recorder key url
-    ```
+  ```haskell
+  get :: FromJSON a => Session -> Ref a -> IO a
+  get sess (Ref url) = jsonGet sess url
+  ```
+
 - `insert` takes a `Ref` to a list and appends an item to it. It returns the
   reference that you passed in because why not.
 
-    ```haskell
-    insert :: ToJSON a => (Session, Recorder) -> String -> Ref [a] -> a -> IO (Ref [a])
-    insert (sess, recorder) key (Ref url) = jsonPost sess recorder key url
-    ```
-- `rpc` unpacks the URL for the RPC endpoint and `POST`s the input, returning the output.
+  ```haskell
+  insert :: ToJSON a => Session -> Ref [a] -> a -> IO (Ref [a])
+  insert sess (Ref url) = jsonPost sess url
+  ```
 
-    ```haskell
-    rpc :: (ToJSON a, FromJSON b) => (Session, Recorder) -> String -> RPC a b -> a -> IO b
-    rpc (sess, recorder) key (RPC url) = jsonPost sess recorder key url
-    ```
+- `rpc` unpacks the URL for the RPC endpoint and `POST`s the input, returning
+  the output.
 
-## The Example API
+  ```haskell
+  rpc :: (ToJSON a, FromJSON b) => Session -> RPC a b -> a -> IO b
+  rpc sess (RPC url) = jsonPost sess url
+  ```
+
+## <a name="The_Example_API"> The Example API
 
 The API requires an initial call to the "/root" to obtain the URLs for
 subsequent calls
@@ -243,114 +253,147 @@ rootRef port = Ref $ T.pack $ "http://localhost:" ++ show port ++ "/root"
 
 ### API Response types
 
-    Calling `GET` on "/root" returns the following JSON  ----------
-                                                                  |
-    Represented here --                                           |
-                      |                                           |
-                      v                                           v
+Calling `GET` on "/root" returns the following JSON  
+
+```json
+{ "products" : "http://localhost:3000/products"
+, "carts"    : "http://localhost:3000/carts"
+, "users"    : "http://localhost:3000/users"
+, "login"    : "http://localhost:3000/login"
+, "checkout" : "http://localhost:3000/checkout"
+}
+```
+
+Which will deserialize to.
+
 ```haskell                                                
 data Root = Root                           
-  { products :: Ref [Ref Product]          --     -- { "products" : "http://localhost:3000/products"
-  , carts    :: Ref [Ref Cart   ]          -- <=> -- , "carts"    : "http://localhost:3000/carts"
-  , users    :: Ref [Ref User   ]          --     -- , "users"    : "http://localhost:3000/users"
-  , login    :: RPC Credentials (Ref User) --     -- , "login"    : "http://localhost:3000/login"
-  , checkout :: RPC (Ref Cart)  ()         --     -- , "checkout" : "http://localhost:3000/checkout"
-  } deriving (Eq, Show, Generic, FromJSON) --     -- }
+  { products :: Ref [Ref Product]          
+  , carts    :: Ref [Ref Cart   ]          
+  , users    :: Ref [Ref User   ]          
+  , login    :: RPC Credentials (Ref User)
+  , checkout :: RPC (Ref Cart)  ()         
+  } deriving (Eq, Show, Generic, FromJSON)
 ```
 
 Since the JSON is so uniform, we can use `aeson`s generic instances.
 
 Calling `GET` on a `Ref Product` or "/products/:id" gives
 
+```json
+{ "summary" : "shirt" }
+```
+
+Which will deserialize to.
+
 ```haskell
-data Product = Product                     --     --
-  { summary :: Text                        -- <=> -- { "summary" : "shirt" }
-  } deriving (Eq, Show, Generic, FromJSON) --     --
+data Product = Product                     
+  { summary :: Text                        
+  } deriving (Eq, Show, Generic, FromJSON)
 ```
 
 Calling `GET` on a `Ref Cart` or "/carts/:id" gives
 
-```haskell
-data Cart = Cart                           --     --
-  { items :: Ref [Ref Product]             -- <=> -- { "items" : ["http://localhost:3000/products/0"] }
-  } deriving (Eq, Show, Generic, FromJSON) --     --
+```json
+{ "items" : ["http://localhost:3000/products/0"] }
 ```
 
-Calling `GET` on a `Ref User` or "/users/:id" gives
+...
 
 ```haskell
-data User = User                           --     --  
-  { cart     :: Ref Cart                   -- <=> -- { "cart"     : "http://localhost:3000/carts/0"
-  , username :: Text                       --     -- , "username" : "example"
-  } deriving (Eq, Show, Generic, FromJSON) --     -- }
+data Cart = Cart                           
+  { items :: Ref [Ref Product]             
+  } deriving (Eq, Show, Generic, FromJSON)
+```
+Calling `GET` on a `Ref User` or "/users/:id" gives
+
+```json
+{ "cart"     : "http://localhost:3000/carts/0"
+, "username" : "example"
+}
+```
+
+```haskell
+data User = User                           
+  { cart     :: Ref Cart                   
+  , username :: Text                       
+  } deriving (Eq, Show, Generic, FromJSON)
 ```
 
 ## RPC Types
 
 The only additional type that we need is the input for the `login` RPC, mainly the `Credentials` type.
 
-```haskell
-data Credentials = Credentials             --     --
-  { password :: Text                       -- <=> -- { "password" : "password"
-  , username :: Text                       --     -- , "username" : "a@example.com"
-  } deriving (Eq, Show, Generic, ToJSON)   --     -- }
+```json
+{ "password" : "password"
+, "username" : "a@example.com"
+}
 ```
 
-## Profiling Script
+```haskell
+data Credentials = Credentials             
+  { password :: Text                       
+  , username :: Text                       
+  } deriving (Eq, Show, Generic, ToJSON)   
+```
+
+## <a name="Profiling_Script"> Profiling Script
 
 We can now easily write our first script!
 
 ```haskell
-testScript :: Int -> Recorder -> IO ()
-testScript port recorder = SWreq.withSessionControl Nothing defaultManagerSettings $ \sess -> do
-  let cfg = (sess, recorder)
+testScript :: Int -> ConnectionContext -> Recorder -> IO ()
+testScript port cxt rec = WW.withSession cxt rec $ \sess -> do
 ```
 Bootstrap the script and get all the URLs for the endpoints. Unpack
-`products`, `login` and `checkout` for use later down.
+`products`, `login` and `checkout` refs for use later down.
 
 ```haskell
   Root { products
        , login
        , checkout
-       } <- get cfg "root" (rootRef port)
+       } <- get sess (rootRef port)
 ```
 We get all products and name the first one
 ```haskell
-  firstProduct : _ <- get cfg "products" products
+  firstProduct : _ <- get sess products
 ```
 
 Login and get the user's ref.
 ```haskell
-  userRef <- rpc cfg "login" login
-                                  ( Credentials
-                                     { username = "a@example.com"
-                                     , password = "password"
-                                     }
-                                  )
+  userRef <- rpc sess login
+                        ( Credentials
+                           { username = "a@example.com"
+                           , password = "password"
+                           }
+                        )
 ```
 Get the user and unpack the user's cart.
 ```haskell
-  User { cart } <- get cfg "user" userRef
+  User { cart } <- get sess userRef
 ```
 Get the cart unpack the items.
 ```haskell
-  Cart { items } <- get cfg "cart" cart
+  Cart { items } <- get sess cart
 ```
 Add the first product to the user's cart's items.
 ```haskell
-  insert cfg "items" items firstProduct
+  insert sess items firstProduct
 ```
 Checkout.
 ```haskell
-  rpc cfg "checkout" checkout cart
+  rpc sess checkout cart
 ```
 
 Port is hard coded to 3000 for this example
 
 ```haskell
-benchmarks :: Int -> [(String, Recorder -> IO ())]
-benchmarks port = [("test0", testScript port)]
+benchmarks :: Int -> IO [(String, Recorder -> IO ())]
+benchmarks port = do
+  -- Create a TLS context once
+  cxt <- Connection.initConnectionContext
+  return [("test0", testScript port cxt)]
 
 main :: IO ()
-main = defaultMain $ benchmarks 3000
+main = defaultMain =<< benchmarks 3000
 ```

--- a/examples/Main.lhs
+++ b/examples/Main.lhs
@@ -89,7 +89,7 @@ main = do
  -- Start the client and close an MVar to signal when the thread has finished
  end <- newEmptyMVar
  forkIO $ do
-     run options $ Client.benchmarks port
+     run options =<< Client.benchmarks port
      putMVar end ()
 
  -- Wait for the client thread to finish and then return

--- a/examples/README.md
+++ b/examples/README.md
@@ -89,7 +89,7 @@ main = do
  -- Start the client and close an MVar to signal when the thread has finished
  end <- newEmptyMVar
  forkIO $ do
-     run options $ Client.benchmarks port
+     run options =<< Client.benchmarks port
      putMVar end ()
 
  -- Wait for the client thread to finish and then return

--- a/examples/Server.hs
+++ b/examples/Server.hs
@@ -171,13 +171,13 @@ stop (_, threadId, ref) = do
 
 toKey :: Wai.Request -> String
 toKey x = case Wai.pathInfo x of
-  ["root"]                  -> "root"
-  ["products"]              -> "products"
-  "carts" : _ : "items" : _ -> "items"
-  "carts" : _ : _           -> "cart"
-  "users" : _               -> "user"
-  ["login"]                 -> "login"
-  ["checkout"]              -> "checkout"
+  ["root"]                  -> "/root"
+  ["products"]              -> "/products"
+  "carts" : _ : "items" : _ -> "/carts/0/items"
+  "carts" : _ : _           -> "/carts/0"
+  "users" : _               -> "/users/0"
+  ["login"]                 -> "/login"
+  ["checkout"]              -> "/checkout"
   _ -> error "FAIL! UNKNOWN REQUEST FOR EXAMPLE!"
 
 recordMiddleware :: Recorder -> Wai.Application -> Wai.Application
@@ -220,10 +220,9 @@ main = do
 
   (Warp.runSettingsSocket defaultSettings socket
                                         $ recordMiddleware recorder
-                                        $ scottyApp) `finally` 
+                                        $ scottyApp) `finally`
     ( do N.close socket
          Immortal.stop recorderThread
          allStats <- NextRef.readLast ref
-         putStrLn $ Wrecker.pprStats Nothing allStats
+         putStrLn $ Wrecker.pprStats Nothing Path allStats
     )
-

--- a/src/Network/Wreq/Wrecker.hs
+++ b/src/Network/Wreq/Wrecker.hs
@@ -1,0 +1,195 @@
+{-# LANGUAGE CPP, RecordWildCards #-}
+module Network.Wreq.Wrecker where
+import Wrecker
+import qualified Network.Wreq.Session as Session
+import Network.Connection (ConnectionContext)
+import qualified Network.HTTP.Client.Internal as HTTP
+import qualified Network.HTTP.Client_0_5_3_2_SHIM as HTTP_SHIM
+import qualified Network.HTTP.Client_0_5_3_2_SHIM.Internal as HTTP_SHIM
+import qualified Network.HTTP.Client.TLS_0_3_3_SHIM as TLS
+import qualified Data.ByteString.Lazy as L
+import qualified Network.Wreq.Types as Wreq
+import Data.Default (def)
+import Data.ByteString (ByteString)
+import Network.Socket
+
+data Session = Session
+  { sSession  :: Session.Session
+  , sRecorder :: Recorder
+  }
+
+toHTTPConnection :: HTTP_SHIM.Connection
+                 -> HTTP.Connection
+toHTTPConnection HTTP_SHIM.Connection {..} = HTTP.Connection {..}
+
+toSHIMConnection :: HTTP.Connection 
+                 -> HTTP_SHIM.Connection
+toSHIMConnection HTTP.Connection {..} = HTTP_SHIM.Connection {..}
+
+convertTlsConnection :: IO (  Maybe HostAddress 
+                           -> String 
+                           -> Int 
+                           -> IO HTTP_SHIM.Connection
+                           )
+                     -> IO (  Maybe HostAddress 
+                           -> String 
+                           -> Int 
+                           -> IO HTTP.Connection
+                           )
+convertTlsConnection
+  = fmap (\f -> \a s i -> fmap toHTTPConnection $ f a s i) 
+
+convertTlsProxyConnection :: IO (  ByteString
+                                -> (HTTP_SHIM.Connection -> IO ())
+                                -> String
+                                -> Maybe HostAddress
+                                -> String
+                                -> Int
+                                -> IO HTTP_SHIM.Connection
+                                )
+                          -> IO (  ByteString
+                                -> (HTTP.Connection -> IO ())
+                                -> String
+                                -> Maybe HostAddress
+                                -> String
+                                -> Int
+                                -> IO HTTP.Connection
+                                )
+convertTlsProxyConnection 
+  = fmap (\f 
+         -> \b g s m s' i 
+            -> fmap toHTTPConnection 
+             $ f b (g . toHTTPConnection) s m s' i
+         ) 
+
+convert :: HTTP_SHIM.ManagerSettings -> HTTP.ManagerSettings
+convert HTTP_SHIM.ManagerSettings {..} = 
+  let d = HTTP.defaultManagerSettings 
+  in HTTP.ManagerSettings
+      { HTTP.managerConnCount           = HTTP.managerConnCount d
+      , HTTP.managerRawConnection       = HTTP.managerRawConnection d
+      , HTTP.managerTlsConnection       = convertTlsConnection 
+                                        $ managerTlsConnection
+      , HTTP.managerTlsProxyConnection  = convertTlsProxyConnection
+                                        $ managerTlsProxyConnection
+      , HTTP.managerResponseTimeout     = HTTP.managerResponseTimeout d
+      , HTTP.managerRetryableException  = HTTP.managerRetryableException d
+      , HTTP.managerWrapIOException     = HTTP.managerWrapIOException d
+      , HTTP.managerIdleConnectionCount = HTTP.managerIdleConnectionCount d
+      , HTTP.managerModifyRequest       = HTTP.managerModifyRequest d
+      , HTTP.managerProxyInsecure       = HTTP.managerProxyInsecure d
+      , HTTP.managerProxySecure         = HTTP.managerProxySecure d
+      }                              
+                          
+-- |
+-- Module      : Network.Wreq.Internal.Types
+-- Copyright   : (c) 2014 Bryan O'Sullivan
+--
+-- License     : BSD-style
+-- Maintainer  : bos@serpentine.com
+-- Stability   : experimental
+-- Portability : GHC
+--
+-- HTTP client types.
+
+-- All of this code below was copied from bos's `Network.Wreq.Session`
+
+defaultManagerSettings :: ConnectionContext -> HTTP.ManagerSettings
+defaultManagerSettings context 
+  = convert 
+  $ (TLS.mkManagerSettingsContext (Just context) def Nothing)
+          { HTTP_SHIM.managerResponseTimeout = HTTP_SHIM.responseTimeoutNone }
+-- | Create a 'Session', passing it to the given function.  The
+-- 'Session' will no longer be valid after that function returns.
+--
+-- This session manages cookies and uses default session manager
+-- configuration.
+withSession :: ConnectionContext -> Recorder -> (Session -> IO a) -> IO a
+withSession context recorder
+  = withSessionControl recorder
+                       (Just (HTTP.createCookieJar []))
+                       (defaultManagerSettings context)
+
+-- | Create a session.
+--
+-- This uses the default session manager settings, but does not manage
+-- cookies.  It is intended for use with REST-like HTTP-based APIs,
+-- which typically do not use cookies.
+withAPISession :: ConnectionContext -> Recorder -> (Session -> IO a) -> IO a
+withAPISession context recorder
+  = withSessionControl recorder
+                       Nothing
+                       (defaultManagerSettings context)
+
+-- | Create a session, using the given cookie jar and manager settings.
+withSessionControl :: Recorder
+                   -> Maybe HTTP.CookieJar
+                   -- ^ If 'Nothing' is specified, no cookie management
+                   -- will be performed.
+                   -> HTTP.ManagerSettings
+                   -> (Session -> IO a) -> IO a
+withSessionControl recorder cookie settings f
+  = Session.withSessionControl cookie settings
+  $ \session -> f (Session session recorder)
+
+-- this records things. It's not ideal, but an more acurate
+-- implementation is harder. Pull requests welcome.
+withSess :: (Session.Session -> String -> IO a) -> Session -> String -> IO a
+withSess f sess key = record (sRecorder sess) key $  f (sSession sess) key
+
+withSess1 :: (Session.Session -> String -> a -> IO b) -> Session -> String -> a -> IO b
+withSess1 f sess key b = record (sRecorder sess) key $  f (sSession sess) key b
+
+-- | 'Session'-specific version of 'Network.Wreq.get'.
+get :: Session -> String -> IO (HTTP.Response L.ByteString)
+get = withSess Session.get
+
+-- | 'Session'-specific version of 'Network.Wreq.post'.
+post :: Wreq.Postable a
+     => Session
+     -> String
+     -> a
+     -> IO (HTTP.Response L.ByteString)
+post = withSess1 Session.post
+
+-- | 'Session'-specific version of 'Network.Wreq.head_'.
+head_ :: Session -> String -> IO (HTTP.Response ())
+head_ = withSess Session.head_
+
+-- | 'Session'-specific version of 'Network.Wreq.options'.
+options :: Session -> String -> IO (HTTP.Response ())
+options = withSess Session.options
+
+-- | 'Session'-specific version of 'Network.Wreq.put'.
+put :: Wreq.Putable a => Session -> String -> a -> IO (HTTP.Response L.ByteString)
+put = withSess1 Session.put
+
+-- | 'Session'-specific version of 'Network.Wreq.delete'.
+delete :: Session -> String -> IO (HTTP.Response L.ByteString)
+delete = withSess Session.delete
+
+-- | 'Session'-specific version of 'Network.Wreq.getWith'.
+getWith :: Wreq.Options -> Session -> String -> IO (HTTP.Response L.ByteString)
+getWith opts = withSess (Session.getWith opts)
+
+-- | 'Session'-specific version of 'Network.Wreq.postWith'.
+postWith :: Wreq.Postable a => Wreq.Options -> Session -> String -> a
+         -> IO (HTTP.Response L.ByteString)
+postWith opts = withSess1 (Session.postWith opts)
+
+-- | 'Session'-specific version of 'Network.Wreq.headWith'.
+headWith :: Wreq.Options -> Session -> String -> IO (HTTP.Response ())
+headWith opts = withSess (Session.headWith opts)
+
+-- | 'Session'-specific version of 'Network.Wreq.optionsWith'.
+optionsWith :: Wreq.Options -> Session -> String -> IO (HTTP.Response ())
+optionsWith opts = withSess (Session.optionsWith opts)
+
+-- | 'Session'-specific version of 'Network.Wreq.putWith'.
+putWith :: Wreq.Putable a => Wreq.Options -> Session -> String -> a
+        -> IO (HTTP.Response L.ByteString)
+putWith opts = withSess1 (Session.putWith opts)
+
+-- | 'Session'-specific version of 'Network.Wreq.deleteWith'.
+deleteWith :: Wreq.Options -> Session -> String -> IO (HTTP.Response L.ByteString)
+deleteWith opts = withSess (Session.deleteWith opts)

--- a/src/Wrecker.hs
+++ b/src/Wrecker.hs
@@ -15,6 +15,7 @@ module Wrecker ( Recorder
                , record
                , run
                , Options          (..)
+               , URLDisplay       (..)
                , RunType          (..)
                , DisplayMode      (..)
                , defaultOptions

--- a/src/Wrecker/Recorder.hs
+++ b/src/Wrecker/Recorder.hs
@@ -4,7 +4,7 @@
 module Wrecker.Recorder where
 import           Control.Concurrent.STM
 import           Control.Concurrent.STM.TBMQueue
-import qualified Network.HTTP.Client as HTTP
+import qualified Network.HTTP.Client_0_5_3_2_SHIM as HTTP
 import qualified Network.HTTP.Types as HTTP
 import           System.Clock
 import           Control.Exception
@@ -111,6 +111,9 @@ record recorder key action = do
         endTime <- getTime Monotonic
         case e of
 #if MIN_VERSION_http_client(0,5,0)
+          HTTP.HttpExceptionRequest _ (HTTP.StatusCodeException resp _) -> do
+            let code = HTTP.statusCode $ HTTP.responseStatus resp
+#elif MIN_VERSION_http_client_zero_five_three_two_shim(0,5,0)
           HTTP.HttpExceptionRequest _ (HTTP.StatusCodeException resp _) -> do
             let code = HTTP.statusCode $ HTTP.responseStatus resp
 #else

--- a/test/ExampleSpec.hs
+++ b/test/ExampleSpec.hs
@@ -12,6 +12,8 @@ import Network.Wai.Handler.Warp (Port)
 import Data.Maybe (fromJust)
 import Control.Concurrent.NextRef (NextRef)
 import qualified Control.Concurrent.NextRef as NextRef
+import qualified Network.Connection as Connection
+import Debug.Trace
 
 {-
   This file tests how well `wrecker` can detect a "signal".
@@ -66,14 +68,18 @@ subtractGaussian x y
 urlStatsToDist :: HashMap String ResultStatistics
                -> Server.Root Gaussian
 urlStatsToDist stats =
-  let gaussians = fmap toDist stats
-      Just root            = H.lookup "root"     gaussians
-      Just products        = H.lookup "products" gaussians
-      Just login           = H.lookup "login"    gaussians
-      Just usersIndex      = H.lookup "user"     gaussians
-      Just cartsIndex      = H.lookup "cart"     gaussians
-      Just cartsIndexItems = H.lookup "items"    gaussians
-      Just checkout        = H.lookup "checkout" gaussians
+  let gaussians =  map (\(key, value) -> ( Stats.urlToPathPieceKey key
+                                        , toDist value
+                                        )
+                      )
+                $ H.toList stats
+      Just root            = lookup "/root"          $ trace (show $ map fst gaussians) $ gaussians
+      Just products        = lookup "/products"      gaussians
+      Just login           = lookup "/login"         gaussians
+      Just usersIndex      = lookup "/users/0"       gaussians
+      Just cartsIndex      = lookup "/carts/0"       gaussians
+      Just cartsIndexItems = lookup "/carts/0/items" gaussians
+      Just checkout        = lookup "/checkout"      gaussians
 
   in Server.Root {..}
 
@@ -107,7 +113,7 @@ class Approx a where
   approx :: a -> a -> Bool
 
 instance Approx Double where
-  approx x y = abs (x - y) < 0.0005
+  approx x y = abs (x - y) < 0.001
 
 instance Approx Gaussian where
   approx x y = approx (mean     x) (mean     y)
@@ -124,17 +130,16 @@ instance Approx a => Approx (Server.Root a) where
 
 
 runWrecker :: Int -> IO AllStats
-runWrecker port
-   =  let key = "key"
-   in fromJust
-   .  H.lookup key
-  <$> Wrecker.run (defaultOptions
-                    { runStyle    = RunCount 250
-                    , displayMode = Interactive
-                    }
-                  )
-                  [ (key, Client.testScript port)
-                  ]
+runWrecker port = do
+  let key = "key"
+  cxt <- Connection.initConnectionContext
+  fromJust . H.lookup key <$> Wrecker.run (defaultOptions
+                                             { runStyle    = RunCount 200
+                                             , displayMode = Interactive
+                                             }
+                                          )
+                                          [ (key, Client.testScript port cxt)
+                                          ]
 
 calculateOverhead :: IO (Server.Root Gaussian)
 calculateOverhead = do
@@ -144,7 +149,7 @@ calculateOverhead = do
 
   -- This how long a 'null' request takes
   serverStats <- NextRef.readLast ref
-  putStrLn $ Stats.pprStats Nothing serverStats
+  putStrLn $ Stats.pprStats Nothing Path serverStats
   killThread threadId
 
   return $ substractDist (urlStatsToDist $ aPerUrl allStats   )

--- a/wrecker.cabal
+++ b/wrecker.cabal
@@ -35,6 +35,7 @@ library
                  , Wrecker.Options
                  , Wrecker.Statistics
                  , Wrecker.Logger
+                 , Network.Wreq.Wrecker
   build-depends: base >= 4.7 && < 5
                , stm
                , stm-chans
@@ -44,10 +45,12 @@ library
                , aeson
                , unix
                , ansigraph
+               , network
                , time
                , clock
                , text
-               , http-client >= 0.4 && < 0.5
+               , http-client-zero-five-three-two-shim
+               , http-client
                , http-types
                , tabular
                , deepseq
@@ -61,6 +64,11 @@ library
                , unagi-chan
                , next-ref
                , immortal
+               , wreq
+               , connection
+               , http-client-tls-zero-three-three-shim
+               , data-default
+               , network-uri
   default-language:    Haskell2010
   ghc-options:         -Wall -fno-warn-unused-do-bind -pgmL markdown-unlit
 
@@ -94,6 +102,7 @@ executable example-client
                      , bytestring
                      , text
                      , http-client
+                     , connection
   cpp-options: -D_CLIENT_IS_MAIN_
   ghc-options: -O2 -Wall -Wno-unused-top-binds -Wno-unused-do-bind -threaded -pgmL markdown-unlit -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
@@ -117,6 +126,7 @@ executable example
                      , next-ref
                      , wai
                      , network
+                     , connection
   ghc-options: -O2 -Wall -Wno-unused-do-bind -O2 -threaded -pgmL markdown-unlit  -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 
@@ -142,5 +152,6 @@ test-suite wrecker-test
                , network
                , immortal
                , next-ref
+               , connection
   ghc-options: -Wall -Wno-unused-do-bind -O2 -threaded  -pgmL markdown-unlit -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010


### PR DESCRIPTION
This uses shims made to use the newer version of http-client-tls with wreq. This is probably the right way to get around the version issues ... and it probably works.
